### PR TITLE
Add podspec. Update cocoapod version to an actual changeset

### DIFF
--- a/YAML-Framework.podspec
+++ b/YAML-Framework.podspec
@@ -1,0 +1,41 @@
+Pod::Spec.new do |s|
+  s.name         = "YAML-Framework"
+  s.version      = "0.0.3"
+  s.summary      = "Proper YAML support for Objective-C. Based on recommended LibYAML."
+  s.description  = "YAML.framework provides support for YAML (de)serialisation similarly to standard NSPropertyListSerialization. Based on C LibYAML library by Kirill Simonov."
+                   
+  s.homepage     = "http://getpocket.com/developer/"
+  s.license      = { :type => 'MIT', :text => <<-TEXT 
+                                Copyright (c) 2010 Mirek Rusin (YAML.framework)
+                                2006 Kirill Simonov (LibYAML)
+
+                                Permission is hereby granted, free of charge, to any person obtaining a copy of
+                                this software and associated documentation files (the \"Software\"), to deal in
+                                the Software without restriction, including without limitation the rights to
+                                use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+                                of the Software, and to permit persons to whom the Software is furnished to do
+                                so, subject to the following conditions:
+
+                                The above copyright notice and this permission notice shall be included in all
+                                copies or substantial portions of the Software.
+
+                                THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                                SOFTWARE.
+                                TEXT
+                  }
+
+  s.authors      = { "Mirek Rusin" => "mirek@me.com", "Kirill Simonov" => "kiril" }
+  s.source       = { :git => "https://github.com/mirek/YAML.framework.git", :tag => "v0.0.3" }
+ 
+  s.requires_arc = false
+  
+  s.source_files = "YAMLSerialization.{h,m}", "yaml-0.1.4/config.h"
+  s.public_header_files = 'YAMLSerialization.h'
+  s.dependency "LibYAML", "~> 0.1.4"
+
+end


### PR DESCRIPTION
I've added podspec to an actual changeset, which can be used in "use_frameworks!" environment. 
If it sounds good for you, it is needed, also, to add a tag v0.0.3 (i've tested with commit: c099c4b9756d116f5fb08bc588d49a43a6c6176c)

To commit podspec it is needed to follow [instructions](https://guides.cocoapods.org/making/getting-setup-with-trunk), but in general, it's a simple execution of the following command:  

`pod trunk push YAML-Framework.podspec`

